### PR TITLE
Replaces "include in export" checkbox with hidden input

### DIFF
--- a/exporter/static/js/field-selection.js
+++ b/exporter/static/js/field-selection.js
@@ -1,0 +1,18 @@
+let checkboxes = document.querySelectorAll(".table-field");
+
+checkboxes.forEach(element => {
+    
+    element.addEventListener('click', function() {
+        const attributes = this.id.split('-')
+        let tableInput = document.getElementById(`id_${attributes[1]}-${attributes[2]}-include_in_export`)
+        const siblingCheckboxes = this.parentElement.parentElement.querySelectorAll('.table-field')
+
+        const anyChecked = Array.from(siblingCheckboxes).some(checkbox => checkbox.checked)
+        if (anyChecked) {
+            tableInput.value = "on"
+        } else {
+            tableInput.value = null
+        }
+
+    })
+})

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -5,25 +5,12 @@
     <h3>{{ table_form.instance.name }} table</h3>
     <div class="input-group mb-20">
         {{ table_form.id }}
-        {% if include_by_default == 'true' %}
-            <input
-                type="hidden"
-                id="{{ table_form.include_in_export.auto_id }}"
-                name="{{ table_form.include_in_export.html_name }}"
-                value="on"
-            />
-        {% else %}
-            <input
-                type="checkbox"
-                class="checkbox checkbox--blue"
-                id="{{ table_form.include_in_export.auto_id }}"
-                name="{{ table_form.include_in_export.html_name }}"
-                {% if table_form.include_in_export.value %}checked="checked"{% endif %}
-            />
-            <label for="{{ table_form.include_in_export.id_for_label }}" class="checkbox--blue">
-                Include in export?
-            </label>
-        {% endif %}
+        <input
+            type="hidden"
+            id="{{ table_form.include_in_export.auto_id }}"
+            name="{{ table_form.include_in_export.html_name }}"
+            value={% if include_by_default == 'true' %}on{% elif table_form.include_in_export.value %}on{%else%}''{% endif %}
+        />
     </div>
 
     {% if table_form.nested %}
@@ -38,7 +25,7 @@
                 {{field_form.id}}
                 <input
                     type="checkbox"
-                    class="checkbox checkbox--blue"
+                    class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
                     id="{{ field_form.include_in_export.auto_id }}"
                     name="{{ field_form.include_in_export.html_name }}"
                     {% if field_form.include_in_export.value %}checked="checked"{% endif %}

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -22,5 +22,6 @@
 
 		{% include 'exporter/includes/footer.html' %}
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
+		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 	</body>
 </html>

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -37,6 +37,7 @@ class CreateExportJobView(CreateView):
         return context
 
     def form_valid(self, form):
+        """Creates Table objects and associates them with the export job."""
         context = self.get_context_data(form=form)
         tables_formset = context['formset']
         if tables_formset.is_valid():
@@ -51,7 +52,6 @@ class CreateExportJobView(CreateView):
                     if field.instance.related_table:
                         related_table, _ = Table.objects.get_or_create(
                             name=field.instance.related_table.name,
-                            include_in_export=form.instance.include_in_export,
                             export_job=self.object
                         )
                     Field.objects.create(


### PR DESCRIPTION
Converts checkbox "include in export" checkbox input into a hidden input whose value is set dynamically by JS when a user clicks on a field checkbox.

fixes #64 