### PR TITLE
Normalize Line Endings Across Environments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings, with Git deciding whether the file is text or binary.
+* text=auto
+
+# Explicitly set LF endings for shell scripts
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
Adds `.gitattributes` file to normalize line endings between environments to fix #76 .
Users will have to remove and clone the repository again for the line ending normalization to be applied.

Also updates the Python version in the Dockerfile to align with requirements.