### PR TITLE
Improve UI messages related to table availability and selected fields

### DIFF
--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -54,12 +54,12 @@
 {% endif %}
 
 <h2>Connected Tables and Fields</h2>
-{% if included_related_tables %}
-    {% for table in included_related_tables %}
+{% if include_related_tables %}
+    {% for table in include_related_tables %}
         {% include 'exporter/includes/inline_table_card.html' with table=table %}
     {% endfor %}
 {% else %}
-    <p >No fields from connected tables were selected for this export.</p>
+    <p>No fields from connected tables were selected for this export.</p>
 {% endif %}
 
 <div class="flex exportjob-buttons__wrapper">

--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -46,14 +46,21 @@
 </dl>
 
 <h2>Grant Request Fields</h2>
-{% include 'exporter/includes/inline_table_card.html' with table=object.grant_request_table %}
+{% if object.grant_request_table %}
+    {% include 'exporter/includes/inline_table_card.html' with table=object.grant_request_table %}
+{% else %}
+    <p class="input__error">No grant request table is available. Before creating an export job, first configure your grant request
+			table to enable exports from Fluxx.</p>
+{% endif %}
 
 <h2>Connected Tables and Fields</h2>
-{% for table in object.related_tables.all %}
-    {% if table.include_in_export %}
+{% if included_related_tables %}
+    {% for table in included_related_tables %}
         {% include 'exporter/includes/inline_table_card.html' with table=table %}
-    {% endif %}
-{% endfor %}
+    {% endfor %}
+{% else %}
+    <p >No fields from connected tables were selected for this export.</p>
+{% endif %}
 
 <div class="flex exportjob-buttons__wrapper">
     <div>

--- a/exporter/templates/exporter/exportjob_form.html
+++ b/exporter/templates/exporter/exportjob_form.html
@@ -34,28 +34,29 @@
 	{% endfor %}
 
 	<h2>Grant Request Fields</h2>
-	<p>Select grant request field/s to include in export job.</p>
 
 	{{formset.management_form}}
 	{% for error in formset.non_form_errors %}
 		<div class="input__error">{{error}}</div>
 	{% endfor %}
-		
-	{% for table_form in formset %}
-		{% if table_form.instance.name == 'grant_request' %}
+
+	{% if grant_request_forms %}
+		{% for table_form in grant_request_forms %}
 			{% include 'exporter/includes/inline_table_form.html' with table_form=table_form include_by_default='true' %}
-		{% endif %}
-	{% endfor %}
+		{% endfor %}
+	{% else %}
+		<p class="input__error">No grant request table is available. Before creating an export job, first configure your grant request 
+			table to enable exports from Fluxx.</p>
+	{% endif %}
 
 	<h2>Connected Tables and Fields</h2>
-	<p>Select connected table/s and associated field/s to include in export job.</p>
-		
-	{% for table_form in formset %}
-		{% if table_form.instance.name != 'grant_request' %}
+	{% if connected_table_forms %}
+		{% for table_form in connected_table_forms %}
 			{% include 'exporter/includes/inline_table_form.html' with table_form=table_form %}
-		{% endif %}
-	{% endfor %}
- 
+		{% endfor %}
+	{% else %}
+		<p>No connected tables are available. If needed, configure connected tables to enable their export from Fluxx.</p>
+	{% endif %}
 
 	<button class="btn btn--md btn--blue" type="submit">Submit</button>
 	<a href="{% if object %}{% url 'exportjob_detail' pk=object.pk %}{% else %}{% url 'index' %}{% endif %}" class="btn btn--md btn--gray" type="cancel">Cancel</a>

--- a/exporter/test_views.py
+++ b/exporter/test_views.py
@@ -47,6 +47,8 @@ class ViewTests(TestCase):
         """Assert custom behavior in get_context_data and is_valid."""
         response = self.client.get(reverse('exportjob_create'))
         self.assertIsInstance(response.context['formset'], ExportJobWithTables)
+        self.assertIn('grant_request_forms', response.context)
+        self.assertIn('connected_table_forms', response.context)
 
         response = self.client.post(reverse('exportjob_create'), self.form_data)
         self.assertEqual(Table.objects.all().count(), 5)
@@ -58,6 +60,8 @@ class ViewTests(TestCase):
         export_job = ExportJob.objects.all().first()
         response = self.client.get(reverse('exportjob_update', kwargs={'pk': export_job.pk}))
         self.assertIsInstance(response.context['formset'], ExportJobWithTables)
+        self.assertIn('grant_request_forms', response.context)
+        self.assertIn('connected_table_forms', response.context)
 
         initial_tables = Table.objects.all().count()
         initial_fields = Field.objects.all().count()

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -25,6 +25,13 @@ class AboutView(TemplateView):
 class ExportJobView(DetailView):
     model = ExportJob
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['include_related_tables'] = [
+            table for table in self.object.related_tables.all() if table.include_in_export
+        ]
+        return context
+
 
 class CreateExportJobView(CreateView):
     model = ExportJob
@@ -34,6 +41,15 @@ class CreateExportJobView(CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['formset'] = ExportJobWithTables(**self.get_form_kwargs())
+        formset = context['formset']
+        context['grant_request_forms'] = [
+            table_form for table_form in formset
+            if getattr(table_form.instance, 'name', None) == 'grant_request'
+        ]
+        context['connected_table_forms'] = [
+            table_form for table_form in formset
+            if getattr(table_form.instance, 'name', None) != 'grant_request'
+        ]
         return context
 
     def form_valid(self, form):
@@ -72,6 +88,15 @@ class UpdateExportJobView(UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['formset'] = ExportJobWithTables(**self.get_form_kwargs())
+        formset = context['formset']
+        context['grant_request_forms'] = [
+            table_form for table_form in formset
+            if getattr(table_form.instance, 'name', None) == 'grant_request'
+        ]
+        context['connected_table_forms'] = [
+            table_form for table_form in formset
+            if getattr(table_form.instance, 'name', None) != 'grant_request'
+        ]
         return context
 
     def form_valid(self, form):

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -27,9 +27,7 @@ class ExportJobView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['include_related_tables'] = [
-            table for table in self.object.related_tables.all() if table.include_in_export
-        ]
+        context['include_related_tables'] = self.object.related_tables.filter(include_in_export=True)
         return context
 
 


### PR DESCRIPTION
Fix #90 

Updates view.py and templates to improve UI messaging related to available tables in export job creation:
- In `exportjob_form` (both Create and Update export job), adds a message warning users when no grant request table is available, and let's them know where no connected tables are available.
- In `exportjob_detail`, adds the same warning message when no grant request table is available, and let's them know when no fields from connected tables were selected.

For review, an extra check that I updated the views (and their tests) correctly to enable easier template logic would be appreciated.

## Messages in create/edit export job:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/d4a82d41-1337-4947-8747-0aef08e76909" />

## Messages in Export Job Details
<img width="573" alt="image" src="https://github.com/user-attachments/assets/45fd4737-6ba5-4253-8a39-9bf8c8abf0fa" />
