### PR TITLE
Sanitize document filenames before saving

### DIFF
--- a/exporter/exporters.py
+++ b/exporter/exporters.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from django.core.exceptions import ObjectDoesNotExist
+from pathvalidate import sanitize_filename
 
 from .clients import AmazonS3Client, FluxxClient
 from .models import ExportJob
@@ -75,8 +76,9 @@ class Exporter(object):
                 for doc_id in record.get('model_documents', []):
                     logging.debug(f'Downloading document {doc_id}')
                     file_name, file_obj = fluxx_client.download_document(doc_id)
-                    logging.debug(f'Saving document {doc_id} with file name {file_name}')
-                    self.save_document(file_name, file_obj, record_path)
+                    sanitized_file_name = sanitize_filename(file_name)
+                    logging.debug(f'Saving document {doc_id} with file name {sanitized_file_name}')
+                    self.save_document(sanitized_file_name, file_obj, record_path)
 
                 if self.amazon_s3_config:
                     logging.info('Uploading to S3')

--- a/exporter/exporters.py
+++ b/exporter/exporters.py
@@ -76,7 +76,7 @@ class Exporter(object):
                 for doc_id in record.get('model_documents', []):
                     logging.debug(f'Downloading document {doc_id}')
                     file_name, file_obj = fluxx_client.download_document(doc_id)
-                    sanitized_file_name = sanitize_filename(file_name)
+                    sanitized_file_name = sanitize_filename(str(file_name))
                     logging.debug(f'Saving document {doc_id} with file name {sanitized_file_name}')
                     self.save_document(sanitized_file_name, file_obj, record_path)
 

--- a/exporter/test_export.py
+++ b/exporter/test_export.py
@@ -73,7 +73,7 @@ class ExportTests(TestCase):
         table = Table.objects.all().first()
         export_dir = Path(export_job.export_location, f"{table.name}_{record_id}")
         model_doc_id = "12345"
-        download_response = (1, 2)
+        download_response = ("1", "2")
         mock_fluxx.return_value = None
         mock_download_doc.return_value = download_response
         mock_s3_init.return_value = None

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ botocore~=1.34
 Django~=5.0
 moto~=5.0
 paramiko~=3.4
+pathvalidate~=3.3
 pysftp~=0.2
 requests~=2.32
 responses~=0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,8 @@ paramiko==3.5.1
     # via
     #   -r requirements.in
     #   pysftp
+pathvalidate==3.3.1
+    # via -r requirements.in
 pycparser==2.22
     # via cffi
 pynacl==1.5.0


### PR DESCRIPTION
Uses the [pathvalidate](https://pypi.org/project/pathvalidate/) library to sanitize filenames before saving. I didn't add a test for this because we're just using a single method from an external library.

fixes #89 