### PR TITLE
Adds rate limiting

### DIFF
--- a/exporter/clients.py
+++ b/exporter/clients.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import boto3
 import paramiko
-import requests
+from requests_ratelimiter import LimiterSession
 
 logging = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class FluxxClient(object):
         }
         logging.debug("OAuth params created")
 
-        self.session = requests.Session()
+        self.session = LimiterSession(per_minute=180)
         logging.debug("Session initiated")
 
         # obtain oauth token

--- a/requirements.in
+++ b/requirements.in
@@ -6,4 +6,5 @@ moto~=5.0
 paramiko~=3.4
 pysftp~=0.2
 requests~=2.32
+requests-ratelimiter~=0.7
 responses~=0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,8 @@ pycparser==2.22
     # via cffi
 pynacl==1.5.0
     # via paramiko
+pyrate-limiter==2.10.0
+    # via requests-ratelimiter
 pysftp==0.2.9
     # via -r requirements.in
 python-dateutil==2.9.0.post0
@@ -68,7 +70,10 @@ requests==2.32.4
     # via
     #   -r requirements.in
     #   moto
+    #   requests-ratelimiter
     #   responses
+requests-ratelimiter==0.7.0
+    # via -r requirements.in
 responses==0.25.7
     # via
     #   -r requirements.in


### PR DESCRIPTION
Implements [requests_ratelimiter](https://github.com/JWCook/requests-ratelimiter) library to support limiting requests per minute, as per Fluxx documentation.

fixes #88