### PR TITLE
Improve export status progress visibility

### DIFF
--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -50,3 +50,10 @@ h2 {
 .toc__skip-link--orange {
     color: #F6F6F4 !important;
 }
+
+/* Set custom focus styles for alert div. When an error appears on page load, 
+focus is programmatically set to the alert. */
+.alert:focus {
+    outline: solid 2px #F6F6F4;
+    outline-offset: -10px;
+}

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -57,3 +57,83 @@ focus is programmatically set to the alert. */
     outline: solid 2px #F6F6F4;
     outline-offset: -10px;
 }
+
+/* Styles to enable micromodal.js */
+.modal__overlay {
+	display: none;
+}
+
+.modal__overlay.is-open {
+	display: block;
+}
+
+/**
+* Override default modal positioning for small centered modal.
+* 1. Change to fixed positioning for viewport centering.
+* 2. Override inset with transform for centering.
+**/
+.modal--small {
+    background: #E3E1DD;
+    position: fixed; /* 1 */
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%); /* 2 */
+    width: 90%;
+    max-width: 500px;
+    min-height: 150px;  
+    max-height: 90vh;
+    overflow-y: auto;
+
+    @media screen and (min-width: 1024px) {
+        padding: 20px;
+        width: 80%;
+        max-width: 600px;
+    }
+}
+
+/**
+* Layout adjustments to default modal styles to include spinner
+**/
+.modal__body {
+    display: block;
+    min-height: auto;
+
+    @media screen and (min-width: 1024px) {
+        display: flex;
+    }
+}
+
+.spinner-container {
+    width: 100%;
+    margin: 0 0 1em;
+    
+    @media screen and (min-width: 1024px) {
+        width: 20%;
+        margin-right: 2.5em;
+    }
+}
+
+/* Spinner styles adapted from rom https://getbootstrap.com/docs/5.0/components/spinners/#border-spinner */
+.spinner-border {
+    display: inline-block;
+    width: 2.0rem;
+    height: 2.0rem;
+    vertical-align: text-bottom;
+    border: 0.30em solid #182C48;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spinner-border 1.0s linear infinite;
+
+    @media screen and (min-width: 1024px) {
+        width: 4.0rem;
+        height: 4.0rem;
+    }
+  }
+  
+  @keyframes spinner-border {
+    to { transform: rotate(360deg); }
+  }
+
+  .modal__body p {
+        font-size: 20px;
+  }

--- a/exporter/static/js/alert-focus.js
+++ b/exporter/static/js/alert-focus.js
@@ -1,0 +1,10 @@
+// On page load, set focus to the first .alert <div> inside #alert-message if it exists
+window.addEventListener('DOMContentLoaded', function () {
+  var alertContainer = document.getElementById('alert-message');
+  if (alertContainer) {
+      var firstAlert = alertContainer.querySelector('.alert');
+      if (firstAlert) {
+          firstAlert.focus();
+      }
+  }
+});

--- a/exporter/static/js/modals.js
+++ b/exporter/static/js/modals.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function() {
+  MicroModal.init();
+});

--- a/exporter/templates/exporter/about.html
+++ b/exporter/templates/exporter/about.html
@@ -1,6 +1,6 @@
 {% extends 'exporter/main.html' %}
 
-{% block title %}Fluxx Exporter - About{% endblock %}
+{% block title %}About - Fluxx Exporter{% endblock %}
 
 {% block content %}
 <h1>About the Fluxx Exporter</h1>

--- a/exporter/templates/exporter/exportjob_confirm_delete.html
+++ b/exporter/templates/exporter/exportjob_confirm_delete.html
@@ -8,8 +8,8 @@
     <h1>Confirm Delete</h1>
     <p>Are you sure you want to delete "{{ object.name }}"?</p>
     {{ form }}
-    <button class="btn btn--md btn--navy" type="submit">Confirm</button>
-    <a href="{% url 'exportjob_detail' pk=object.pk %}" class="btn btn--md btn--orange">Cancel</a>
+    <button class="btn btn--md btn--orange" type="submit">Delete</button>
+    <a href="{% url 'exportjob_detail' pk=object.pk %}" class="btn btn--md btn--gray">Cancel</a>
 </form>
 
 {% endblock %}

--- a/exporter/templates/exporter/exportjob_confirm_delete.html
+++ b/exporter/templates/exporter/exportjob_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends 'exporter/main.html' %}
 
-{% block title %}Fluxx Exporter - Confirm Deletion of {{object.name}}{% endblock %}
+{% block title %}Confirm Deletion of {{object.name}} - Fluxx Exporter{% endblock %}
 
 {% block content %}
 

--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -1,6 +1,6 @@
 {% extends 'exporter/main.html' %}
 
-{% block title %}Fluxx Exporter - {{object.name}}{% endblock %}
+{% block title %}{{object.name}} - Fluxx Exporter{% endblock %}
 
 {% block content %}
 

--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -67,7 +67,7 @@
         <a class="btn btn--md btn--light-blue" href="{% url 'exportjob_update' pk=object.pk %}">Edit</a>
         <a class="btn btn--md btn--orange" href="{% url 'exportjob_delete' pk=object.pk %}">Delete</a>
     </div>
-    <a class="btn btn--md btn--navy" href="{% url 'exportjob_run' pk=object.pk %}">Run</a>
+    <a class="btn btn--md btn--blue" href="{% url 'exportjob_run' pk=object.pk %}">Run Export</a>
 </div>
 
 {% endblock %}

--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -67,7 +67,7 @@
         <a class="btn btn--md btn--light-blue" href="{% url 'exportjob_update' pk=object.pk %}">Edit</a>
         <a class="btn btn--md btn--orange" href="{% url 'exportjob_delete' pk=object.pk %}">Delete</a>
     </div>
-    <a class="btn btn--md btn--blue" href="{% url 'exportjob_run' pk=object.pk %}">Run Export</a>
+    <a data-micromodal-trigger="export-progress-modal" class="btn btn--md btn--blue" href="{% url 'exportjob_run' pk=object.pk %}">Run Export</a>
 </div>
 
 {% endblock %}

--- a/exporter/templates/exporter/exportjob_form.html
+++ b/exporter/templates/exporter/exportjob_form.html
@@ -60,7 +60,7 @@
 		<p>No connected tables are available. If needed, configure connected tables to enable their export from Fluxx.</p>
 	{% endif %}
 
-	<button id="submit-btn" class="btn btn--md btn--blue" type="submit">Submit</button>
+	<button id="submit-btn" class="btn btn--md btn--blue" type="submit">Save</button>
 	<a href="{% if object %}{% url 'exportjob_detail' pk=object.pk %}{% else %}{% url 'index' %}{% endif %}" class="btn btn--md btn--gray" type="cancel">Cancel</a>
 
 </form>

--- a/exporter/templates/exporter/exportjob_form.html
+++ b/exporter/templates/exporter/exportjob_form.html
@@ -1,6 +1,6 @@
 {% extends 'exporter/main.html' %}
 
-{% block title %}Fluxx Exporter - {% if form.instance.id %}Edit {{form.instance.name}}{% else %}Create New Export Job{% endif %}{% endblock %}
+{% block title %}{% if form.instance.id %}Edit {{form.instance.name}}{% else %}Create New Export Job{% endif %} - Fluxx Exporter{% endblock %}
 
 {% block content %}
 

--- a/exporter/templates/exporter/import_form.html
+++ b/exporter/templates/exporter/import_form.html
@@ -1,6 +1,6 @@
 {% extends 'exporter/main.html' %}
 
-{% block title %}Fluxx Exporter - Import{% endblock %}
+{% block title %}Import Tables and Fields - Fluxx Exporter{% endblock %}
 
 {% block content %}
 <h1>Import Tables and Fields</h1>

--- a/exporter/templates/exporter/includes/export_progress_modal.html
+++ b/exporter/templates/exporter/includes/export_progress_modal.html
@@ -1,0 +1,16 @@
+<div class="modal__overlay" id="export-progress-modal" aria-hidden="true">
+  <div data-micromodal-close>
+    <div tabindex="-1" class="modal modal--small" role="dialog" aria-modal="true" aria-label="Export in progress">
+      <div class="modal__body">
+        <div class="spinner-container">
+          <div class="spinner-border mb-10" aria-hidden="true">
+            <span class="visually-hidden">Loading...</span>
+          </div>
+        </div>
+        <div>
+          <p>Fluxx export is in progress...</p>
+          <p>Large exports can take several minutes to complete.</p>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/exporter/templates/exporter/includes/export_progress_modal.html
+++ b/exporter/templates/exporter/includes/export_progress_modal.html
@@ -1,16 +1,14 @@
 <div class="modal__overlay" id="export-progress-modal" aria-hidden="true">
-  <div data-micromodal-close>
-    <div tabindex="-1" class="modal modal--small" role="dialog" aria-modal="true" aria-label="Export in progress">
-      <div class="modal__body">
-        <div class="spinner-container">
-          <div class="spinner-border mb-10" aria-hidden="true">
-            <span class="visually-hidden">Loading...</span>
-          </div>
+  <div tabindex="-1" class="modal modal--small" role="dialog" aria-modal="true" aria-label="Export in progress">
+    <div class="modal__body">
+      <div class="spinner-container">
+        <div class="spinner-border mb-10" aria-hidden="true">
+          <span class="visually-hidden">Loading...</span>
         </div>
-        <div>
-          <p>Fluxx export is in progress...</p>
-          <p>Large exports can take several minutes to complete.</p>
-        </div>
+      </div>
+      <div>
+        <p>Fluxx export is in progress...</p>
+        <p>Large exports can take several minutes to complete.</p>
       </div>
     </div>
   </div>

--- a/exporter/templates/exporter/includes/export_progress_modal.html
+++ b/exporter/templates/exporter/includes/export_progress_modal.html
@@ -1,6 +1,6 @@
 <div class="modal__overlay" id="export-progress-modal" aria-hidden="true">
   <div tabindex="-1" class="modal modal--small" role="dialog" aria-modal="true" aria-label="Export in progress">
-    <div class="modal__body">
+    <div tabindex="0" class="modal__body">
       <div class="spinner-container">
         <div class="spinner-border mb-10" aria-hidden="true">
           <span class="visually-hidden">Loading...</span>

--- a/exporter/templates/exporter/includes/messages.html
+++ b/exporter/templates/exporter/includes/messages.html
@@ -1,19 +1,23 @@
+{% load static %}
 {% if messages %}
-    {% for message in messages %}
-        {% if message.tags == 'error' %}
-            <div class="alert alert--orange">
-                <span class="alert__icon" aria-hidden="true">error_outline</span>
-                <div>
-                    <p class="alert__text">{{message}}</p>
+    <div id="alert-message">
+        {% for message in messages %}
+            {% if message.tags == 'error' %}
+                <div tabindex="-1" class="alert alert--orange">
+                    <span class="alert__icon" aria-hidden="true">error_outline</span>
+                    <div>
+                        <p class="alert__text">{{message}}</p>
+                    </div>
                 </div>
-            </div>
-        {% else %}
-            <div class="alert alert--blue">
-                <span class="alert__icon" aria-hidden="true">check_circle_outline</span>
-                <div>
-                    <p class="alert__text">{{message}}</p>
+            {% else %}
+                <div class="alert alert--blue">
+                    <span class="alert__icon" aria-hidden="true">check_circle_outline</span>
+                    <div>
+                        <p class="alert__text">{{message}}</p>
+                    </div>
                 </div>
-            </div>
-        {% endif %}
-    {% endfor %}
+            {% endif %}
+        {% endfor %}
+    </div>
+    <script type="text/javascript" src="{% static 'js/alert-focus.js' %}"></script>
 {% endif %}

--- a/exporter/templates/exporter/includes/messages.html
+++ b/exporter/templates/exporter/includes/messages.html
@@ -1,11 +1,19 @@
 {% if messages %}
-    <ul class="list--unstyled">
-        {% for message in messages %}
-            {% if message.tags == 'error' %}
-                <li class="alert alert--orange" role="status">{{message}}</li>
-            {% else %}
-                <li class="alert alert--blue" role="status">{{message}}</li>
-            {% endif %}
-        {% endfor %}
-    </ul>
+    {% for message in messages %}
+        {% if message.tags == 'error' %}
+            <div class="alert alert--orange">
+                <span class="alert__icon" aria-hidden="true">error_outline</span>
+                <div>
+                    <p class="alert__text">{{message}}</p>
+                </div>
+            </div>
+        {% else %}
+            <div class="alert alert--blue">
+                <span class="alert__icon" aria-hidden="true">check_circle_outline</span>
+                <div>
+                    <p class="alert__text">{{message}}</p>
+                </div>
+            </div>
+        {% endif %}
+    {% endfor %}
 {% endif %}

--- a/exporter/templates/exporter/index.html
+++ b/exporter/templates/exporter/index.html
@@ -6,7 +6,7 @@
     <h1>Fluxx Exporter</h1>
 
     <div class="create-export-job">
-        <a href="{% url 'exportjob_create' %}" class="btn btn--lg btn--navy">Create New Export Job</a>
+        <a href="{% url 'exportjob_create' %}" class="btn btn--lg btn--blue">Create New Export Job</a>
     </div>
 
     <div class="export-job-list">

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -21,9 +21,12 @@
 		</div>
 
 		{% include 'exporter/includes/footer.html' %}
+		{% include 'exporter/includes/export_progress_modal.html' %}
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-filter.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/skip-to-header.js' %}"></script>
+		<script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>
+		<script type="text/javascript" src="{% static 'js/modals.js' %}"></script>
 	</body>
 </html>


### PR DESCRIPTION
Fix #101 
Implements a modal that appears after the "Run Export" button is pressed, but before page load when export is complete/stops because of error, that let's users know that the export is in progress.
- Adds [micromodal.js](https://micromodal.vercel.app/) to handle modal functionality.
- Add custom styles for modal and associated progress spinner.

Also cleans up a couple few things: 
- Aligns the `messages.html` structure with the [existing RAC alert component](https://styles.rockarch.org/?path=/docs/components-alert--docs). Also adds the `alert-focus.js` script to focus on the alert text when the page loads for better accessibility, since using the aria role="status" won't work as a live announcement in this context because the page reloads before the message appears.
- Adjusts page titles so that page-specific info is first before application name
- Aligns use of button colors
- Updates some button/link labels for clarity of function.

A couple things I considered:
1. I chose not to implement a more complicated approach with things happening in the background or trying to get more granular progress updates, because that would be a bigger lift. I think this addresses the need we saw in testing for an indication that long-running exports are still ongoing, and will prevent users from re-clicking on the "Run Export" link while they're waiting. We can see how this works for users, and iterate later as necessary.
2. I thought about delaying the appearance of the modal for a second so that if the export is really fast, there isn't this flash of a modal appearing and then disappearing. Open to opinions about implementing that.

<img width="1182" height="683" alt="image" src="https://github.com/user-attachments/assets/8a840f4c-f0c4-411d-a99c-d0f1431076de" />
