### PR TITLE
Adds help text for export location in form

### DIFF
--- a/exporter/forms.py
+++ b/exporter/forms.py
@@ -89,7 +89,10 @@ class ExportJobForm(ModelForm):
         model = ExportJob
         exclude = ('sftp_config',)
         help_texts = {
-            'export_location': 'Directory in which exported records will be saved.',
+            'export_location': 'Enter a path to a directory in which exported records will be saved. \
+                This can be an absolute path, or a path relative to the Fluxx Exporter executable file. \
+                You must have write permissions for this location. \
+                If this directory does not exist, Fluxx Exporter will attempt to create it.',
             'filter_string': 'Filters which grant records are exported.',
             'grant_ids': 'Comma-separated list of Fluxx grant IDs to export.',
         }

--- a/exporter/forms.py
+++ b/exporter/forms.py
@@ -91,7 +91,7 @@ class ExportJobForm(ModelForm):
         help_texts = {
             'export_location': 'Path to the directory where exported records will be saved. \
                 Path can be absolute, or relative to the Fluxx Exporter executable file. \
-                Directory will be created if it does not exist.
+                Directory will be created if it does not exist.',
             'filter_string': 'Filters which grant records are exported.',
             'grant_ids': 'Comma-separated list of Fluxx grant IDs to export.',
         }

--- a/exporter/forms.py
+++ b/exporter/forms.py
@@ -89,10 +89,9 @@ class ExportJobForm(ModelForm):
         model = ExportJob
         exclude = ('sftp_config',)
         help_texts = {
-            'export_location': 'Enter a path to a directory in which exported records will be saved. \
-                This can be an absolute path, or a path relative to the Fluxx Exporter executable file. \
-                You must have write permissions for this location. \
-                If this directory does not exist, Fluxx Exporter will attempt to create it.',
+            'export_location': 'Path to the directory where exported records will be saved. \
+                Path can be absolute, or relative to the Fluxx Exporter executable file. \
+                Directory will be created if it does not exist.
             'filter_string': 'Filters which grant records are exported.',
             'grant_ids': 'Comma-separated list of Fluxx grant IDs to export.',
         }


### PR DESCRIPTION
Adds a (fairly lengthy) help text for the export location field. Would welcome suggestions for how to shorten this.

Fixes #98 