### PR TITLE
debugs duplicate table creation

### DIFF
--- a/exporter/views.py
+++ b/exporter/views.py
@@ -62,8 +62,9 @@ class CreateExportJobView(CreateView):
             for form in tables_formset:
                 new_table, _ = Table.objects.get_or_create(
                     name=form.instance.name,
-                    include_in_export=form.instance.include_in_export,
                     export_job=self.object)
+                new_table.include_in_export = form.instance.include_in_export
+                new_table.save()
                 for field in form.nested:
                     related_table = None
                     if field.instance.related_table:


### PR DESCRIPTION
Uses the same parameters in `get_or_create` to avoid cases where differences in the `include_in_export` value was causing duplicate tables to be created.

What was happening here was that, since the fields for each table are handled inside the for loop for that table, the first time through the loop (the grant request table) was creating all the other tables with `include_in_export` set to False. Then, when the other tables were looped through, they were created again with `include_in_export` set to True. 

Fixes #91