### PR TITLE
Add new navigation and context to homepage

### DIFF
--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -31,6 +31,12 @@ h2 {
     overflow: hidden;
 }
 
+.card-list {
+    @media screen and (min-width: 1024px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
 .card h3 {
     margin-top: 0px;
 }

--- a/exporter/templates/exporter/includes/navbar.html
+++ b/exporter/templates/exporter/includes/navbar.html
@@ -26,6 +26,14 @@
           <li class="nav__item btn--navy">
             <a
               class="nav__link"
+              href="{% url 'exportjob_create' %}"
+              id="create-export">
+              Create Export
+            </a>
+          </li>
+          <li class="nav__item btn--navy">
+            <a
+              class="nav__link"
               href="{% url 'about' %}"
               id="about">
               About
@@ -57,6 +65,14 @@
                 href="{% url 'import' %}"
                 tabindex="-1">
                 Import
+              </a>
+            </li>
+            <li>
+              <a
+                class="btn btn--navy dropdown__btn dropdown__btn--mobile"
+                href="{% url 'exportjob_create' %}"
+                tabindex="-1">
+                Create Export
               </a>
             </li>
             <li>

--- a/exporter/templates/exporter/index.html
+++ b/exporter/templates/exporter/index.html
@@ -9,7 +9,7 @@
         <div class="card card--container p-20">
             <div class="card__body">
                 <h2 class="card__title">Step 1. Configure Fluxx Instance</h2>
-                <p class="card__body-text">Sign into the admin interface to configure your Fluxx instance to enable exports.</p>
+                <p class="card__body-text">Sign into the admin interface to configure your Fluxx instance and enable exports.</p>
             </div>
             <div class="card__footer">
                 <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'admin:index' %}">Access Admin Console</a>

--- a/exporter/templates/exporter/index.html
+++ b/exporter/templates/exporter/index.html
@@ -5,20 +5,46 @@
 
     <h1>Fluxx Exporter</h1>
 
-    <div class="create-export-job">
-        <a href="{% url 'exportjob_create' %}" class="btn btn--lg btn--blue">Create New Export Job</a>
+    <div class="card-list">
+        <div class="card card--container p-20">
+            <div class="card__body">
+                <h2 class="card__title">Step 1. Configure Fluxx Instance</h2>
+                <p class="card__body-text">Sign into the admin interface to configure your Fluxx instance to enable exports.</p>
+            </div>
+            <div class="card__footer">
+                <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'admin:index' %}">Access Admin Console</a>
+            </div>
+        </div>
+        <div class="card card--container p-20">
+            <div class="card__body">
+                <h2 class="card__title">Step 2. Configure Tables and Fields</h2>
+                <p class="card__body-text">Import your downloaded Fluxx HTML API documentation pages to configure Fluxx tables and fields.</p>
+            </div>
+            <div class="card__footer">
+                <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'import' %}">Import API Files</a>
+            </div>
+        </div>
+        <div class="card card--container p-20">
+            <div class="card__body">
+                <h2 class="card__title">Step 3. Create a Custom Export</h2>
+                <p class="card__body-text">Create a new export job and run it to export specific grant records from Fluxx.</p>
+            </div>
+            <div class="card__footer">
+                <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'exportjob_create' %}">Create Export Job</a>
+            </div>
+        </div>
     </div>
 
-    <div class="export-job-list">
+    <div class="mt-50">
         {% if export_jobs %}
-            <h2 class="mt-20">Saved Export Jobs</h2>
-            <ul class="list--unstyled">
+            <h2>Saved Export Jobs</h2>
+            <ol>
                 {% for job in export_jobs %}
                     <li>
                         <a href="{% url 'exportjob_detail' pk=job.pk %}">{{job.name}}</a>
                     </li>
                 {% endfor %}
-            </ul>
+            </ol>
         {% endif %}
     </div>
 


### PR DESCRIPTION
Fix #125 

Adds cards to homepage with links to actions and one-sentence descriptions. Also make saved exports job into an ordered list.

Considered: 
- Adding links back to documentation in README for each step, but this feels like it will add maintenance debt that is not worth it.
- Adding a mention of S3 bucket to the config. Decided to leave that for the README.

<img width="1374" height="633" alt="image" src="https://github.com/user-attachments/assets/862610b4-04d1-4c67-afdd-2779b4cba7bf" />
