### PR TITLE
Add relative position to parent

### DIFF
--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -7,6 +7,7 @@ and adds a scrollbar if the content exceeds that height. */
 .checkbox-list {
     max-height: 512px;
     overflow: auto;
+    position: relative;
 }
 
 .exportjob-buttons__wrapper {


### PR DESCRIPTION
When checkboxes have absolute positioning, the parent container needs to have relative positioning. 

Fixes #144 