### PR TITLE
Update Dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/pycqa/isort
-  rev: 6.0.1
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/jazzband/pip-tools
-  rev: v7.5.0
+  rev: v7.5.1
   hooks:
     - id: pip-compile
       args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ bcrypt==5.0.0
     # via paramiko
 beautifulsoup4==4.14.2
     # via -r requirements.in
-boto3==1.40.52
+boto3==1.40.64
     # via
     #   -r requirements.in
     #   moto
-botocore==1.40.52
+botocore==1.40.64
     # via
     #   -r requirements.in
     #   boto3
@@ -22,7 +22,7 @@ cffi==2.0.0
     #   pynacl
 charset-normalizer==3.4.4
     # via requests
-cryptography==46.0.2
+cryptography==46.0.3
     # via
     #   moto
     #   paramiko
@@ -40,7 +40,7 @@ markupsafe==3.0.3
     # via
     #   jinja2
     #   werkzeug
-moto==5.1.14
+moto==5.1.16
     # via -r requirements.in
 paramiko==3.5.1
     # via


### PR DESCRIPTION
Bypassing CI because of a pip-tools update that isn't working with the recent version of pip