### PR TITLE
Update build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           credential_id: ${{ secrets.ES_CREDENTIAL_ID }}
           totp_secret: ${{ secrets.ES_TOTP_SECRET }}
           file_path: ${{ env.DIST_NAME }}/fluxx_exporter.exe
-          output_path: ${{ env.DIST_NAME }}
+          output_path: signed
           override: false
           malware_block: true
           clean_logs: true
@@ -55,17 +55,14 @@ jobs:
       - name: Create zip file (windows)
         if: matrix.os == 'windows'
         run: |
+          move signed\fluxx_exporter.exe ${{ env.DIST_NAME }}\fluxx_exporter.exe
+          rmdir /s /q signed
           Compress-Archive -Path "${{ env.DIST_NAME }}" -DestinationPath "${{ env.DIST_NAME }}.zip"
 
       - name: Create zip file (linux)
         if: matrix.os != 'windows'
         run: |
             zip -r ${{ env.DIST_NAME }}.zip ${{ env.DIST_NAME }}
-
-      - uses: softprops/action-gh-release@v2.5.0
-        if: github.ref_type == 'tag' && matrix.os == 'windows'
-        with:
-          files: ${{ env.DIST_NAME }}/${{ env.DIST_NAME }}.exe
 
       - uses: softprops/action-gh-release@v2.5.0
         if: github.ref_type == 'tag'


### PR DESCRIPTION
Clean up build file to sign to temp directory and then overwrite unsigned exe. Only upload one artifact for windows.