### PR TITLE
feat: Improves bulk selection/deselection of checkbox inputs in Export Jobs

### DIFF
--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -158,3 +158,13 @@ focus is programmatically set to the alert. */
   .modal__body p {
         font-size: 20px;
   }
+
+/* Disable text selection for checkbox labels during multi-select
+*  while still allowing intentional selection of label text */
+.checkbox + label {
+    &:active {
+        user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+    }
+}

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,0 +1,31 @@
+let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
+var lastChecked = null;
+
+multiSelectCheckboxes.forEach(element => {
+    element.addEventListener('click', function(e) {
+        if (!lastChecked) {
+            lastChecked = this;
+            return;
+        }
+
+        if (e.shiftKey) {
+            const siblingCheckboxes = [...this.parentElement.parentElement.children].filter(c => c.classList.contains('input-group'))
+
+            const from = siblingCheckboxes.indexOf(this.parentElement)
+            const to = siblingCheckboxes.indexOf(lastChecked.parentElement)
+
+            const start = Math.min(from, to);
+            const end = Math.max(from, to) + 1;
+
+            const toControl = siblingCheckboxes.slice(start, end)
+
+            toControl.forEach(el => {
+                let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
+                checkbox.checked = lastChecked.checked
+            })
+        }
+
+        lastChecked = this;
+
+    })
+})

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,10 +1,12 @@
 let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
-var lastChecked = null;
+let lastChecked = null;
+let lastCheckedCheckbox = null; 
 
 multiSelectCheckboxes.forEach(element => {
     element.addEventListener('click', function(e) {
         if (!lastChecked) {
             lastChecked = this;
+            lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
             return;
         }
 
@@ -21,11 +23,12 @@ multiSelectCheckboxes.forEach(element => {
 
             toControl.forEach(el => {
                 let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
-                checkbox.checked = lastChecked.checked
+                checkbox.checked = lastCheckedCheckbox.checked
             })
         }
 
         lastChecked = this;
+        lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
 
     })
 })

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,12 +1,10 @@
 let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
 let lastChecked = null;
-let lastCheckedCheckbox = null; 
 
 multiSelectCheckboxes.forEach(element => {
     element.addEventListener('click', function(e) {
         if (!lastChecked) {
             lastChecked = this;
-            lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
             return;
         }
 
@@ -23,12 +21,11 @@ multiSelectCheckboxes.forEach(element => {
 
             toControl.forEach(el => {
                 let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
-                checkbox.checked = lastCheckedCheckbox.checked
+                checkbox.checked = lastChecked.checked
             })
         }
 
         lastChecked = this;
-        lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
 
     })
 })

--- a/exporter/static/js/select-toggle.js
+++ b/exporter/static/js/select-toggle.js
@@ -1,0 +1,12 @@
+let selectToggleCheckboxes = document.querySelectorAll(".select-toggle");
+
+selectToggleCheckboxes.forEach(element => {
+    
+    element.addEventListener('click', function() {
+        const prefix = this.id.replace('_select-toggle', '')
+        const toControl = this.parentElement.parentElement.querySelectorAll(`[id*="${prefix}"]`)
+
+        // Show or hide all visible checkboxes
+        Array.from(toControl).map(c => c.offsetParent? c.checked = this.checked : null)
+    })
+})

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -23,12 +23,12 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                    class="checkbox checkbox--blue"
+                    class="checkbox checkbox--blue multi-select"
                     id="{{ field.include_in_export.auto_id }}"
                     name="{{ field.include_in_export.html_name }}"
                     {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
-                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
+                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
                     {{field.instance.name}}
                 </label>
             </div>

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -6,7 +6,7 @@
 {% endfor %}
 <div class="card card--container card--brown mb-10">
     <fieldset>
-        <legend id="legend" class="mb-20">Available document types</legend>
+        <legend class="mb-20">Available document types</legend>
         <div class="input-group mb-20">
             <input
                 type="checkbox"
@@ -17,7 +17,7 @@
                 Select all document types
             </label>
         </div>
-        <div aria-describedby="legend" class="checkbox-list">
+        <div class="checkbox-list">
             {% for field in form %}
             <div class="input-group">
                 {{field.id}}

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -23,12 +23,12 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                    class="checkbox checkbox--blue multi-select"
+                    class="checkbox checkbox--blue"
                     id="{{ field.include_in_export.auto_id }}"
                     name="{{ field.include_in_export.html_name }}"
                     {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
-                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
+                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
                     {{field.instance.name}}
                 </label>
             </div>

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -7,7 +7,17 @@
 <div class="card card--container card--brown mb-10">
     <fieldset>
         <legend id="legend" class="mb-20">Available document types</legend>
-            <div aria-describedby="legend" class="checkbox-list">
+        <div class="input-group mb-20">
+            <input
+                type="checkbox"
+                    class="checkbox checkbox--blue select-toggle"
+                    id="{{ form.prefix }}_select-toggle"
+            />
+            <label for="{{ form.prefix }}_select-toggle" class="checkbox--blue">
+                Select all document types
+            </label>
+        </div>
+        <div aria-describedby="legend" class="checkbox-list">
             {% for field in form %}
             <div class="input-group">
                 {{field.id}}

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -10,8 +10,8 @@
         <div class="input-group mb-20">
             <input
                 type="checkbox"
-                    class="checkbox checkbox--blue select-toggle"
-                    id="{{ form.prefix }}_select-toggle"
+                class="checkbox checkbox--blue select-toggle"
+                id="{{ form.prefix }}_select-toggle"
             />
             <label for="{{ form.prefix }}_select-toggle" class="checkbox--blue">
                 Select all document types
@@ -23,10 +23,10 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                        class="checkbox checkbox--blue"
-                        id="{{ field.include_in_export.auto_id }}"
-                        name="{{ field.include_in_export.html_name }}"
-                        {% if field.include_in_export.value %}checked="checked"{% endif %}
+                    class="checkbox checkbox--blue multi-select"
+                    id="{{ field.include_in_export.auto_id }}"
+                    name="{{ field.include_in_export.html_name }}"
+                    {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
                 <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
                     {{field.instance.name}}

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -43,12 +43,12 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %} multi-select"
+                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}
                     />
-                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue">
+                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
                         {{ field_form.instance.name }}{% if field_form.instance.related_table.id %} <span class="text--italic">(connected data type: {{field_form.instance.related_table.name}})</span>{% endif %}
                     </label>
                 </div>

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -43,12 +43,12 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
+                        class="checkbox checkbox--blue multi-select{% if include_by_default != 'true' %} table-field{% endif %}"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}
                     />
-                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
+                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue">
                         {{ field_form.instance.name }}{% if field_form.instance.related_table.id %} <span class="text--italic">(connected data type: {{field_form.instance.related_table.name}})</span>{% endif %}
                     </label>
                 </div>

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -29,8 +29,8 @@
             <div class="input-group mb-20">
                 <input
                     type="checkbox"
-                        class="checkbox checkbox--blue select-toggle"
-                        id="{{ table_form.prefix }}_select-toggle"
+                    class="checkbox checkbox--blue select-toggle"
+                    id="{{ table_form.prefix }}_select-toggle"
                 />
                 <label for="{{ table_form.prefix }}_select-toggle" class="checkbox--blue">
                     Select all fields
@@ -43,7 +43,7 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
+                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %} multi-select"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -18,7 +18,7 @@
         {{table_form.nested.non_form_errors}}
 
         <fieldset>
-            <legend id="legend" class="mb-20">Fields for {{ table_form.instance.name }}</legend>
+            <legend class="mb-20">Fields for {{ table_form.instance.name }}</legend>
             <div class="input exportjob__fields-filter mb-20">
                 <label for="filter-{{ table_form.prefix }}">Search for fields:</label>
                 <input type="text"
@@ -36,7 +36,7 @@
                     Select all fields
                 </label>
             </div>
-            <div tabindex="0" aria-describedby="legend" class="checkbox-list">
+            <div class="checkbox-list">
                 <a href="#" class="toc__skip-link toc__skip-link--orange">Skip to next section</a>
                 {% for field_form in table_form.nested.forms %}
                 <div class="input-group">

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -26,6 +26,16 @@
                     class="checkbox-filter"
                     oninput="filterCheckboxes(this)">
             </div>
+            <div class="input-group mb-20">
+                <input
+                    type="checkbox"
+                        class="checkbox checkbox--blue select-toggle"
+                        id="{{ table_form.prefix }}_select-toggle"
+                />
+                <label for="{{ table_form.prefix }}_select-toggle" class="checkbox--blue">
+                    Select all fields
+                </label>
+            </div>
             <div tabindex="0" aria-describedby="legend" class="checkbox-list">
                 <a href="#" class="toc__skip-link toc__skip-link--orange">Skip to next section</a>
                 {% for field_form in table_form.nested.forms %}

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -25,6 +25,7 @@
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-filter.js' %}"></script>
+		<script type="text/javascript" src="{% static 'js/multi-select.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/select-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/skip-to-header.js' %}"></script>
 		<script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -25,6 +25,7 @@
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-filter.js' %}"></script>
+		<script type="text/javascript" src="{% static 'js/select-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/skip-to-header.js' %}"></script>
 		<script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>
 		<script type="text/javascript" src="{% static 'js/modals.js' %}"></script>


### PR DESCRIPTION
Makes selecting or deselecting checkboxes in bulk easier by allowing users to toggle selection/deselection of all checkboxes in a fieldset through an additional checkbox control and selecting a range of checkboxes by holding down the shift key.

Notes:
- If table fields are filtered via the search input, only the visible fields will be checked or unchecked.