### PR TITLE
fix: improve accessibility of page titles, form labels, and buttons

### DIFF
--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -1,5 +1,9 @@
 .content {
-    grid-column: 3 / span 8;
+    grid-column: 2 / span 10;
+
+    @media screen and (min-width: 36.25em) {
+        grid-column: 3 / span 8;
+    }
 }
 
 /* limits the group of checkboxes to a maximum height of 512px
@@ -157,4 +161,9 @@ focus is programmatically set to the alert. */
 
   .modal__body p {
     font-size: 20px;
+  }
+
+/* Allow button text to wrap to support text resizing for accessibility. */ 
+  .btn--block {
+    white-space: wrap;
   }

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -168,10 +168,16 @@ focus is programmatically set to the alert. */
     white-space: wrap;
   }
 
-  .input label {
-    display: inline-block;
-  }
-
   .input label:has(+ input[required])::after {
     content: " *";
   }
+
+/* Disable text selection for checkbox labels during multi-select
+*  while still allowing intentional selection of label text */
+.checkbox + label {
+    &:active {
+        user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+    }
+}

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -6,10 +6,10 @@
     }
 }
 
-/* limits the group of checkboxes to a maximum height of 512px
-and adds a scrollbar if the content exceeds that height. */
+/* Limits the group of checkboxes to a maximum height that cuts off a checkbox to indicate 
+that there are more options to scroll to, and adds a scrollbar if the content exceeds that height. */
 .checkbox-list {
-    max-height: 512px;
+    max-height: 500px;
     overflow: auto;
     position: relative;
 }

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -158,3 +158,13 @@ focus is programmatically set to the alert. */
   .modal__body p {
         font-size: 20px;
   }
+
+/* Disable text selection for checkbox labels during multi-select
+*  while still allowing intentional selection of label text */
+.checkbox + label {
+    &:active {
+        user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+    }
+}

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -17,7 +17,7 @@ and adds a scrollbar if the content exceeds that height. */
 .exportjob__fields-filter {
     width: 100%;
 
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         width: 50%;
     }
 }
@@ -42,7 +42,7 @@ h2 {
 }
 
 .card-list {
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         grid-template-columns: repeat(3, 1fr);
     }
   }
@@ -105,7 +105,7 @@ focus is programmatically set to the alert. */
     max-height: 90vh;
     overflow-y: auto;
 
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         padding: 20px;
         width: 80%;
         max-width: 600px;
@@ -119,7 +119,7 @@ focus is programmatically set to the alert. */
     display: block;
     min-height: auto;
 
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         display: flex;
     }
 }
@@ -128,7 +128,7 @@ focus is programmatically set to the alert. */
     width: 100%;
     margin: 0 0 1em;
     
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         width: 20%;
         margin-right: 2.5em;
     }
@@ -145,16 +145,16 @@ focus is programmatically set to the alert. */
     border-radius: 50%;
     animation: spinner-border 1.0s linear infinite;
 
-    @media screen and (min-width: 1024px) {
+    @media screen and (min-width: 64em) {
         width: 4.0rem;
         height: 4.0rem;
     }
   }
-  
+
   @keyframes spinner-border {
     to { transform: rotate(360deg); }
   }
 
   .modal__body p {
-        font-size: 20px;
+    font-size: 20px;
   }

--- a/exporter/static/css/styles.css
+++ b/exporter/static/css/styles.css
@@ -167,3 +167,11 @@ focus is programmatically set to the alert. */
   .btn--block {
     white-space: wrap;
   }
+
+  .input label {
+    display: inline-block;
+  }
+
+  .input label:has(+ input[required])::after {
+    content: " *";
+  }

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,0 +1,31 @@
+let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
+var lastChecked = null;
+
+multiSelectCheckboxes.forEach(element => {
+    element.addEventListener('click', function(e) {
+        if (!lastChecked) {
+            lastChecked = this;
+            return;
+        }
+
+        if (e.shiftKey) {
+            const siblingCheckboxes = [...this.parentElement.parentElement.children].filter(c => c.classList.contains('input-group'))
+
+            const from = siblingCheckboxes.indexOf(this.parentElement)
+            const to = siblingCheckboxes.indexOf(lastChecked.parentElement)
+
+            const start = Math.min(from, to);
+            const end = Math.max(from, to) + 1;
+
+            const toControl = siblingCheckboxes.slice(start, end)
+
+            toControl.forEach(el => {
+                let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
+                checkbox.checked = lastChecked.checked
+            })
+        }
+
+        lastChecked = this;
+
+    })
+})

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,10 +1,12 @@
 let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
-var lastChecked = null;
+let lastChecked = null;
+let lastCheckedCheckbox = null; 
 
 multiSelectCheckboxes.forEach(element => {
     element.addEventListener('click', function(e) {
         if (!lastChecked) {
             lastChecked = this;
+            lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
             return;
         }
 
@@ -21,11 +23,12 @@ multiSelectCheckboxes.forEach(element => {
 
             toControl.forEach(el => {
                 let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
-                checkbox.checked = lastChecked.checked
+                checkbox.checked = lastCheckedCheckbox.checked
             })
         }
 
         lastChecked = this;
+        lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
 
     })
 })

--- a/exporter/static/js/multi-select.js
+++ b/exporter/static/js/multi-select.js
@@ -1,12 +1,10 @@
 let multiSelectCheckboxes = document.querySelectorAll('.multi-select')
 let lastChecked = null;
-let lastCheckedCheckbox = null; 
 
 multiSelectCheckboxes.forEach(element => {
     element.addEventListener('click', function(e) {
         if (!lastChecked) {
             lastChecked = this;
-            lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
             return;
         }
 
@@ -23,12 +21,11 @@ multiSelectCheckboxes.forEach(element => {
 
             toControl.forEach(el => {
                 let checkbox = [...el.children].find(c => c.classList.contains('checkbox'))
-                checkbox.checked = lastCheckedCheckbox.checked
+                checkbox.checked = lastChecked.checked
             })
         }
 
         lastChecked = this;
-        lastCheckedCheckbox = [...this.parentElement.children].find(c => c.classList.contains('checkbox'))
 
     })
 })

--- a/exporter/static/js/select-toggle.js
+++ b/exporter/static/js/select-toggle.js
@@ -1,0 +1,12 @@
+let selectToggleCheckboxes = document.querySelectorAll(".select-toggle");
+
+selectToggleCheckboxes.forEach(element => {
+    
+    element.addEventListener('click', function() {
+        const prefix = this.id.replace('_select-toggle', '')
+        const toControl = this.parentElement.parentElement.querySelectorAll(`[id*="${prefix}"]`)
+
+        // Show or hide all visible checkboxes
+        Array.from(toControl).map(c => c.offsetParent? c.checked = this.checked : null)
+    })
+})

--- a/exporter/templates/exporter/amazons3config_form.html
+++ b/exporter/templates/exporter/amazons3config_form.html
@@ -17,9 +17,11 @@
 	{{ form.management_form }}
 	{{ form.non_form_errors }}
 
+	<p> All fields required</p>
+
 	{% for field in form %}
 		<div class="input mb-10">
-			{{ field.label_tag }}{% if field.field.required %} *{%endif%}
+			{{ field.label_tag }}
 				{{ field }}
 				{% if field.errors %}
 						<div id="{{field.auto_id}}-error" class="input__error">

--- a/exporter/templates/exporter/configurations_list.html
+++ b/exporter/templates/exporter/configurations_list.html
@@ -4,8 +4,8 @@
 
     <h1>Configurations</h1>
 
-    <a href="{% url 'fluxxconfig_create' %}" class="btn btn--lg btn--blue">Create New Fluxx Config</a>
-    <a href="{% url 'amazons3config_create' %}" class="btn btn--lg btn--blue">Create New Amazon S3 Config</a>
+    <a href="{% url 'fluxxconfig_create' %}" class="btn btn--lg btn--blue mb-5">Create New Fluxx Config</a>
+    <a href="{% url 'amazons3config_create' %}" class="btn btn--lg btn--blue mb-5">Create New Amazon S3 Config</a>
 
     <div class="flex">
         {% if fluxx_configs %}

--- a/exporter/templates/exporter/exportjob_detail.html
+++ b/exporter/templates/exporter/exportjob_detail.html
@@ -84,7 +84,9 @@
         <a class="btn btn--md btn--light-blue" href="{% url 'exportjob_update' pk=object.pk %}">Edit</a>
         <a class="btn btn--md btn--orange" href="{% url 'exportjob_delete' pk=object.pk %}">Delete</a>
     </div>
-    <a data-micromodal-trigger="export-progress-modal" class="btn btn--md btn--blue" href="{% url 'exportjob_run' pk=object.pk %}">Run Export</a>
+    <div>
+        <a data-micromodal-trigger="export-progress-modal" class="btn btn--md btn--blue" href="{% url 'exportjob_run' pk=object.pk %}">Run Export</a>
+    </div>
 </div>
 
 {% endblock %}

--- a/exporter/templates/exporter/exportjob_form.html
+++ b/exporter/templates/exporter/exportjob_form.html
@@ -18,6 +18,8 @@
 	{{ form.management_form }}
 	{{ form.non_form_errors }}
 
+	<p> *Required field</p>
+
 	{% for field in form %}
 		{% if field.name == 'download_all_file_versions' %}
 		<div class="input-group mb-10">

--- a/exporter/templates/exporter/fluxxconfig_form.html
+++ b/exporter/templates/exporter/fluxxconfig_form.html
@@ -17,9 +17,11 @@
 	{{ form.management_form }}
 	{{ form.non_form_errors }}
 
+	<p> All fields required</p>
+
 	{% for field in form %}
 		<div class="input mb-10">
-			{{ field.label_tag }}{% if field.field.required %} *{%endif%}
+			{{ field.label_tag }}
 				{{ field }}
 				{% if field.errors %}
 						<div id="{{field.auto_id}}-error" class="input__error">

--- a/exporter/templates/exporter/import_form.html
+++ b/exporter/templates/exporter/import_form.html
@@ -16,9 +16,11 @@
 	{{ form.management_form }}
 	{{ form.non_form_errors }}
 
+	<p> *Required field</p>
+
 	{% for field in form %}
 		<div class="input mb-10">
-			{{ field.label_tag }}{% if field.field.required %} *{%endif%}
+			{{ field.label_tag }}
 				{{ field }}
 				{% if field.errors %}
 						<div id="{{field.auto_id}}-error" class="input__error">

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -23,12 +23,12 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                    class="checkbox checkbox--blue"
+                    class="checkbox checkbox--blue multi-select"
                     id="{{ field.include_in_export.auto_id }}"
                     name="{{ field.include_in_export.html_name }}"
                     {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
-                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
+                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
                     {{field.instance.name}}
                 </label>
             </div>

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -6,7 +6,7 @@
 {% endfor %}
 <div class="card card--container card--brown mb-10">
     <fieldset>
-        <legend id="legend" class="mb-20">Available document types</legend>
+        <legend class="mb-20">Available document types</legend>
         <div class="input-group mb-20">
             <input
                 type="checkbox"
@@ -17,7 +17,7 @@
                 Select all document types
             </label>
         </div>
-        <div aria-describedby="legend" class="checkbox-list">
+        <div class="checkbox-list">
             {% for field in form %}
             <div class="input-group">
                 {{field.id}}

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -4,10 +4,10 @@
 {% for error in form.non_field_errors %}
     <div class="input__error">{{error}}</div>
 {% endfor %}
-<div class="card card--container card--brown mb-10">
+<div class="card card--container py-20 pr-20 pl-15 mb-20">
     <fieldset>
-        <legend class="mb-20">Available document types</legend>
-        <div class="input-group mb-20">
+        <legend class="mb-20 pl-5">Available document types</legend>
+        <div class="input-group mb-20 pl-5">
             <input
                 type="checkbox"
                 class="checkbox checkbox--blue select-toggle"
@@ -17,7 +17,7 @@
                 Select all document types
             </label>
         </div>
-        <div class="checkbox-list">
+        <div class="checkbox-list pt-5 pl-5">
             {% for field in form %}
             <div class="input-group">
                 {{field.id}}

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -23,12 +23,12 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                    class="checkbox checkbox--blue multi-select"
+                    class="checkbox checkbox--blue"
                     id="{{ field.include_in_export.auto_id }}"
                     name="{{ field.include_in_export.html_name }}"
                     {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
-                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
+                <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
                     {{field.instance.name}}
                 </label>
             </div>

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -7,7 +7,17 @@
 <div class="card card--container card--brown mb-10">
     <fieldset>
         <legend id="legend" class="mb-20">Available document types</legend>
-            <div aria-describedby="legend" class="checkbox-list">
+        <div class="input-group mb-20">
+            <input
+                type="checkbox"
+                    class="checkbox checkbox--blue select-toggle"
+                    id="{{ form.prefix }}_select-toggle"
+            />
+            <label for="{{ form.prefix }}_select-toggle" class="checkbox--blue">
+                Select all document types
+            </label>
+        </div>
+        <div aria-describedby="legend" class="checkbox-list">
             {% for field in form %}
             <div class="input-group">
                 {{field.id}}

--- a/exporter/templates/exporter/includes/document_type_form.html
+++ b/exporter/templates/exporter/includes/document_type_form.html
@@ -10,8 +10,8 @@
         <div class="input-group mb-20">
             <input
                 type="checkbox"
-                    class="checkbox checkbox--blue select-toggle"
-                    id="{{ form.prefix }}_select-toggle"
+                class="checkbox checkbox--blue select-toggle"
+                id="{{ form.prefix }}_select-toggle"
             />
             <label for="{{ form.prefix }}_select-toggle" class="checkbox--blue">
                 Select all document types
@@ -23,10 +23,10 @@
                 {{field.id}}
                 <input
                     type="checkbox"
-                        class="checkbox checkbox--blue"
-                        id="{{ field.include_in_export.auto_id }}"
-                        name="{{ field.include_in_export.html_name }}"
-                        {% if field.include_in_export.value %}checked="checked"{% endif %}
+                    class="checkbox checkbox--blue multi-select"
+                    id="{{ field.include_in_export.auto_id }}"
+                    name="{{ field.include_in_export.html_name }}"
+                    {% if field.include_in_export.value %}checked="checked"{% endif %}
                 />
                 <label for="{{ field.include_in_export.id_for_label }}" class="checkbox--blue">
                     {{field.instance.name}}

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -43,12 +43,12 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %} multi-select"
+                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}
                     />
-                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue">
+                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
                         {{ field_form.instance.name }}{% if field_form.instance.related_table.id %} <span class="text--italic">(connected data type: {{field_form.instance.related_table.name}})</span>{% endif %}
                     </label>
                 </div>

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -43,12 +43,12 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
+                        class="checkbox checkbox--blue multi-select{% if include_by_default != 'true' %} table-field{% endif %}"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}
                     />
-                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue multi-select">
+                    <label for="{{ field_form.include_in_export.id_for_label }}" class="checkbox--blue">
                         {{ field_form.instance.name }}{% if field_form.instance.related_table.id %} <span class="text--italic">(connected data type: {{field_form.instance.related_table.name}})</span>{% endif %}
                     </label>
                 </div>

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -1,9 +1,9 @@
 {% for error in table_form.non_field_errors %}
     <div class="input__error">{{error}}</div>
 {% endfor %}
-<div class="card card--container flex--column p-20 mb-20">
-    <h3 class="mb-20">{{ table_form.instance.name }} table</h3>
-    <div class="input-group">
+<div class="card card--container flex--column py-20 pr-20 pl-15 mb-20">
+    <h3 class="mb-20 pl-5">{{ table_form.instance.name }} table</h3>
+    <div class="input-group pl-5">
         {{ table_form.id }}
         <input
             type="hidden"
@@ -18,15 +18,15 @@
         {{table_form.nested.non_form_errors}}
 
         <fieldset>
-            <legend class="mb-20">Fields for {{ table_form.instance.name }}</legend>
-            <div class="input exportjob__fields-filter mb-20">
+            <legend class="mb-20 pl-5">Fields for {{ table_form.instance.name }}</legend>
+            <div class="input exportjob__fields-filter mb-20 pl-5">
                 <label for="filter-{{ table_form.prefix }}">Search for fields:</label>
                 <input type="text"
                     id="filter-{{ table_form.prefix }}"
                     class="checkbox-filter"
                     oninput="filterCheckboxes(this)">
             </div>
-            <div class="input-group mb-20">
+            <div class="input-group mb-20 pl-5">
                 <input
                     type="checkbox"
                     class="checkbox checkbox--blue select-toggle"
@@ -36,7 +36,7 @@
                     Select all fields
                 </label>
             </div>
-            <div class="checkbox-list">
+            <div class="checkbox-list pt-5 pl-5">
                 <a href="#" class="toc__skip-link toc__skip-link--orange">Skip to next section</a>
                 {% for field_form in table_form.nested.forms %}
                 <div class="input-group">

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -29,8 +29,8 @@
             <div class="input-group mb-20">
                 <input
                     type="checkbox"
-                        class="checkbox checkbox--blue select-toggle"
-                        id="{{ table_form.prefix }}_select-toggle"
+                    class="checkbox checkbox--blue select-toggle"
+                    id="{{ table_form.prefix }}_select-toggle"
                 />
                 <label for="{{ table_form.prefix }}_select-toggle" class="checkbox--blue">
                     Select all fields
@@ -43,7 +43,7 @@
                     {{field_form.id}}
                     <input
                         type="checkbox"
-                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %}"
+                        class="checkbox checkbox--blue{% if include_by_default != 'true' %} table-field{% endif %} multi-select"
                         id="{{ field_form.include_in_export.auto_id }}"
                         name="{{ field_form.include_in_export.html_name }}"
                         {% if field_form.include_in_export.value %}checked="checked"{% endif %}

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -18,7 +18,7 @@
         {{table_form.nested.non_form_errors}}
 
         <fieldset>
-            <legend id="legend" class="mb-20">Fields for {{ table_form.instance.name }}</legend>
+            <legend class="mb-20">Fields for {{ table_form.instance.name }}</legend>
             <div class="input exportjob__fields-filter mb-20">
                 <label for="filter-{{ table_form.prefix }}">Search for fields:</label>
                 <input type="text"
@@ -36,7 +36,7 @@
                     Select all fields
                 </label>
             </div>
-            <div tabindex="0" aria-describedby="legend" class="checkbox-list">
+            <div class="checkbox-list">
                 <a href="#" class="toc__skip-link toc__skip-link--orange">Skip to next section</a>
                 {% for field_form in table_form.nested.forms %}
                 <div class="input-group">

--- a/exporter/templates/exporter/includes/inline_table_form.html
+++ b/exporter/templates/exporter/includes/inline_table_form.html
@@ -26,6 +26,16 @@
                     class="checkbox-filter"
                     oninput="filterCheckboxes(this)">
             </div>
+            <div class="input-group mb-20">
+                <input
+                    type="checkbox"
+                        class="checkbox checkbox--blue select-toggle"
+                        id="{{ table_form.prefix }}_select-toggle"
+                />
+                <label for="{{ table_form.prefix }}_select-toggle" class="checkbox--blue">
+                    Select all fields
+                </label>
+            </div>
             <div tabindex="0" aria-describedby="legend" class="checkbox-list">
                 <a href="#" class="toc__skip-link toc__skip-link--orange">Skip to next section</a>
                 {% for field_form in table_form.nested.forms %}

--- a/exporter/templates/exporter/index.html
+++ b/exporter/templates/exporter/index.html
@@ -12,7 +12,7 @@
                 <p class="card__body-text">Configure your Fluxx instance and export locations.</p>
             </div>
             <div class="card__footer">
-                <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'configurations_list' %}">Create Configurations</a>
+                <a class="btn btn--md btn--blue btn--block mb-10" href="{% url 'configurations_list' %}">Create Configs</a>
             </div>
         </div>
         <div class="card card--container p-20">

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -6,7 +6,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>{% block title %}Fluxx Exporter{% endblock %}</title>
 		<link rel="icon" type="image/x-icon" href="https://assets.rockarch.org/assets/img/favicon.ico">
-		<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v1.0.4/main.min.css">
+		<link rel="stylesheet" type="text/css" href="https://assets.rockarch.org/v2.0.9/main.min.css">
 		<link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}">
 	</head>
 	<body>

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -25,6 +25,7 @@
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-filter.js' %}"></script>
+		<script type="text/javascript" src="{% static 'js/multi-select.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/select-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/skip-to-header.js' %}"></script>
 		<script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>

--- a/exporter/templates/exporter/main.html
+++ b/exporter/templates/exporter/main.html
@@ -25,6 +25,7 @@
 		<script type="text/javascript" src="{% static 'js/nav-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-selection.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/field-filter.js' %}"></script>
+		<script type="text/javascript" src="{% static 'js/select-toggle.js' %}"></script>
 		<script type="text/javascript" src="{% static 'js/skip-to-header.js' %}"></script>
 		<script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>
 		<script type="text/javascript" src="{% static 'js/modals.js' %}"></script>


### PR DESCRIPTION
**Branched from issue-221 - don't merge before that branch.**

Accessibility fixes that address #233 

- Updates to RAC style library version 2.0.9 to improve keyboard focus styles (and adds some space between inputs for those styles) and navigation accessibility
- Improves button layout and styles to work better on mobile/magnified screens and allow for text resizing to 200%. This includes a combination of a button label change (use "config" instead of "configuration", allowing label wrapping, and making more horizontal space on the page for small/magnified screens. 
- Uses unique page titles and headings for the create config pages
- The new style library creates more space between checkbox inputs for focus styles. This PR adds more padding to ensure those focus styles are not cut off in the scrollable checkboxes.
- Improves required field indicators by ensuring the "*" is part of the label using CSS and including a legend or "all fields required" message to conform to WCAG success criteria 3.3.2 Labels or Instructions.
