### PR TITLE
fix: raise obvious error if file download fails

### DIFF
--- a/exporter/clients.py
+++ b/exporter/clients.py
@@ -158,7 +158,10 @@ class FluxxClient(object):
         document_download_url = f"{self.api_url}model_document_download/{document_id}"
         logging.debug(document_download_url)
 
-        return self.session.get(document_download_url, stream=True)
+        resp = self.session.get(document_download_url, stream=True)
+        if resp.status_code != 200:
+            raise Exception(f"Error downloading document with ID {document_id}: {resp.text}")
+        return resp
 
 
 class SFTPClient(object):

--- a/exporter/test_clients.py
+++ b/exporter/test_clients.py
@@ -147,6 +147,7 @@ class FluxxClientTests(SimpleTestCase):
     def test_download_document(self, mock_get, mock_post):
         """Asserts calls to Fluxx API and correct return from function."""
 
+        mock_get.return_value.status_code = 200
         mock_post.return_value.json.return_value = {"access_token": self.access_token}
         client = FluxxClient(self.base_url, self.client_id, self.client_secret)
 
@@ -155,6 +156,11 @@ class FluxxClientTests(SimpleTestCase):
         mock_get.assert_called_once_with(
             f'{self.base_url}/api/rest/v2/model_document_download/{document_id}',
             stream=True)
+
+        mock_get.return_value.status_code = 404
+        with self.assertRaises(Exception) as err:
+            client.download_document(document_id)
+        self.assertTrue(str(err.exception).startswith(f"Error downloading document with ID {document_id}"))
 
     @patch('requests.Session.post')
     @patch('exporter.clients.FluxxClient.get')


### PR DESCRIPTION
Throw an exception if file cannot be downloaded.